### PR TITLE
Dragon following fix [1.18.2]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.daemon=false
 
 mod_id = dragonmounts
 mod_name = Dragon Mounts: Legacy
-mod_version = 1.1.3
+mod_version = 1.1.5a
 # https://minecraft.fandom.com/wiki/Tutorials/Creating_a_data_pack#%22pack_format%22
 game_pack_format = 9
 forge_resource_format = 9

--- a/src/main/java/com/github/kay9/dragonmounts/dragon/TameableDragon.java
+++ b/src/main/java/com/github/kay9/dragonmounts/dragon/TameableDragon.java
@@ -108,6 +108,9 @@ public class TameableDragon extends TamableAnimal implements Saddleable, FlyingA
     private int reproCount;
     private float ageProgress;
 
+    private final GroundPathNavigation groundNavigation;
+    private final FlyingPathNavigation flyingNavigation;
+
     public TameableDragon(EntityType<? extends TameableDragon> type, Level level)
     {
         super(type, level);
@@ -119,6 +122,11 @@ public class TameableDragon extends TamableAnimal implements Saddleable, FlyingA
         moveControl = new DragonMoveController(this);
         animator = level.isClientSide? new DragonAnimator(this) : null;
         breed = BreedRegistry.getFallback();
+
+        flyingNavigation = new FlyingPathNavigation(this, level);
+        groundNavigation = new GroundPathNavigation(this, level);
+
+        navigation = groundNavigation;
     }
 
     @Override
@@ -277,8 +285,8 @@ public class TameableDragon extends TamableAnimal implements Saddleable, FlyingA
 
     public void setNavigation(boolean flying) {
             navigation = flying ?
-                    new FlyingPathNavigation(this, level) :
-                    new GroundPathNavigation(this, level);
+                    flyingNavigation :
+                    groundNavigation;
     }
 
     @Override

--- a/src/main/java/com/github/kay9/dragonmounts/dragon/TameableDragon.java
+++ b/src/main/java/com/github/kay9/dragonmounts/dragon/TameableDragon.java
@@ -80,8 +80,6 @@ public class TameableDragon extends TamableAnimal implements Saddleable, FlyingA
     public static final double BASE_SPEED_FLYING = 0.525;
     public static final double BASE_DAMAGE = 8;
     public static final double BASE_HEALTH = 60;
-    public static final double BASE_FOLLOW_RANGE = 16;
-    public static final double BASE_FOLLOW_RANGE_FLYING = BASE_FOLLOW_RANGE * 2;
     public static final int BASE_KB_RESISTANCE = 1;
     public static final float BASE_WIDTH = 2.75f; // adult sizes
     public static final float BASE_HEIGHT = 2.75f;
@@ -135,7 +133,6 @@ public class TameableDragon extends TamableAnimal implements Saddleable, FlyingA
         return Mob.createMobAttributes()
                 .add(MOVEMENT_SPEED, BASE_SPEED_GROUND)
                 .add(MAX_HEALTH, BASE_HEALTH)
-                .add(ATTACK_DAMAGE, BASE_FOLLOW_RANGE)
                 .add(KNOCKBACK_RESISTANCE, BASE_KB_RESISTANCE)
                 .add(ATTACK_DAMAGE, BASE_DAMAGE)
                 .add(FLYING_SPEED, BASE_SPEED_FLYING);
@@ -299,10 +296,6 @@ public class TameableDragon extends TamableAnimal implements Saddleable, FlyingA
             {
                 // notify client
                 setFlying(flying);
-
-                // update AI follow range (needs to be updated before creating
-                // new PathNavigate!)
-                getAttribute(FOLLOW_RANGE).setBaseValue(flying? BASE_FOLLOW_RANGE_FLYING : BASE_FOLLOW_RANGE);
 
                 // update pathfinding method
                 setNavigation(flying);

--- a/src/main/java/com/github/kay9/dragonmounts/dragon/TameableDragon.java
+++ b/src/main/java/com/github/kay9/dragonmounts/dragon/TameableDragon.java
@@ -278,6 +278,12 @@ public class TameableDragon extends TamableAnimal implements Saddleable, FlyingA
         entityData.set(DATA_FLYING, flying);
     }
 
+    public void setNavigation(boolean flying) {
+            navigation = flying ?
+                    new FlyingPathNavigation(this, level) :
+                    new GroundPathNavigation(this, level);
+    }
+
     @Override
     public void tick()
     {
@@ -299,8 +305,7 @@ public class TameableDragon extends TamableAnimal implements Saddleable, FlyingA
                 getAttribute(FOLLOW_RANGE).setBaseValue(flying? BASE_FOLLOW_RANGE_FLYING : BASE_FOLLOW_RANGE);
 
                 // update pathfinding method
-                if (flying) navigation = new FlyingPathNavigation(this, level);
-                else navigation = new GroundPathNavigation(this, level);
+                setNavigation(flying);
             }
         }
         else

--- a/src/main/java/com/github/kay9/dragonmounts/dragon/TameableDragon.java
+++ b/src/main/java/com/github/kay9/dragonmounts/dragon/TameableDragon.java
@@ -6,6 +6,7 @@ import com.github.kay9.dragonmounts.DragonMountsLegacy;
 import com.github.kay9.dragonmounts.client.DragonAnimator;
 import com.github.kay9.dragonmounts.dragon.ai.DragonBodyController;
 import com.github.kay9.dragonmounts.dragon.ai.DragonBreedGoal;
+import com.github.kay9.dragonmounts.dragon.ai.DragonFollowOwnerGoal;
 import com.github.kay9.dragonmounts.dragon.ai.DragonMoveController;
 import com.github.kay9.dragonmounts.dragon.breed.BreedRegistry;
 import com.github.kay9.dragonmounts.dragon.breed.DragonBreed;
@@ -147,7 +148,7 @@ public class TameableDragon extends TamableAnimal implements Saddleable, FlyingA
         goalSelector.addGoal(2, new SitWhenOrderedToGoal(this));
         goalSelector.addGoal(3, new MeleeAttackGoal(this, 1, true));
 //        goalSelector.addGoal(4, new DragonBabuFollowParent(this, 10));
-        goalSelector.addGoal(5, new FollowOwnerGoal(this, 1.1, 10f, 3.5f, true));
+        goalSelector.addGoal(5, new DragonFollowOwnerGoal(this, 1.1, 10f, 3.5f, 32f));
         goalSelector.addGoal(5, new DragonBreedGoal(this));
         goalSelector.addGoal(6, new WaterAvoidingRandomStrollGoal(this, 1));
         goalSelector.addGoal(7, new LookAtPlayerGoal(this, LivingEntity.class, 16f));

--- a/src/main/java/com/github/kay9/dragonmounts/dragon/ai/DragonFollowOwnerGoal.java
+++ b/src/main/java/com/github/kay9/dragonmounts/dragon/ai/DragonFollowOwnerGoal.java
@@ -1,0 +1,179 @@
+package com.github.kay9.dragonmounts.dragon.ai;
+
+import com.github.kay9.dragonmounts.dragon.TameableDragon;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.entity.ai.navigation.FlyingPathNavigation;
+import net.minecraft.world.entity.ai.navigation.GroundPathNavigation;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.LeavesBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.pathfinder.BlockPathTypes;
+import net.minecraft.world.level.pathfinder.WalkNodeEvaluator;
+
+import java.util.EnumSet;
+
+/**
+ * Goal for dragon to follow its owner.
+ * <p></p>
+ * Mostly copied from <code>FollowOwnerGoal</code>, but with some modifications to fix an issue.
+ * Also allows dragon to tp to owner in the air so they don't get stuck until the owner lands.
+ *
+ * @author AnimalsWritingCode
+ *
+ * @see net.minecraft.world.entity.ai.goal.FollowOwnerGoal
+ */
+public class DragonFollowOwnerGoal extends Goal {
+    private static final int MIN_HORIZONTAL_DISTANCE_FROM_PLAYER_WHEN_TELEPORTING = 2;
+    private static final int MAX_HORIZONTAL_DISTANCE_FROM_PLAYER_WHEN_TELEPORTING = 3;
+    private static final int MIN_VERTICAL_DISTANCE_FROM_PLAYER_WHEN_TELEPORTING = 0;
+    private static final int MAX_VERTICAL_DISTANCE_FROM_PLAYER_WHEN_TELEPORTING = 1;
+    private final TameableDragon dragon;
+    private final LevelReader level;
+    private final double speedModifier;
+    private int timeToRecalcPath;
+    private final float stopDistance;
+    private final float startDistance;
+    private final float teleportDistance;
+    private float oldWaterCost;
+
+    public DragonFollowOwnerGoal(TameableDragon dragon, double speedModifier, float startDistance, float stopDistance, float teleportDistance) {
+        this.dragon = dragon;
+        this.level = dragon.level;
+        this.speedModifier = speedModifier;
+        this.startDistance = startDistance;
+        this.stopDistance = stopDistance;
+        this.teleportDistance = teleportDistance;
+        this.setFlags(EnumSet.of(Goal.Flag.MOVE, Goal.Flag.LOOK));
+        if (!(dragon.getNavigation() instanceof GroundPathNavigation) && !(dragon.getNavigation() instanceof FlyingPathNavigation)) {
+            throw new IllegalArgumentException("Unsupported mob type for FollowOwnerGoal");
+        }
+    }
+
+    public boolean canUse() {
+        LivingEntity livingentity = this.dragon.getOwner();
+        if (livingentity == null) {
+            return false;
+        } else if (livingentity.isSpectator()) {
+            return false;
+        } else if (this.dragon.isOrderedToSit()) {
+            return false;
+        } else if (this.dragon.distanceToSqr(livingentity) < (double)(this.startDistance * this.startDistance)) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public boolean canContinueToUse() {
+        if (this.dragon.getNavigation().isDone()) {
+            return false;
+        } else if (this.dragon.isOrderedToSit()) {
+            return false;
+        } else {
+            return !(this.dragon.distanceToSqr(this.dragon.getOwner()) <= (double)(this.stopDistance * this.stopDistance));
+        }
+    }
+
+    public void start() {
+        this.timeToRecalcPath = 0;
+        this.oldWaterCost = this.dragon.getPathfindingMalus(BlockPathTypes.WATER);
+        this.dragon.setPathfindingMalus(BlockPathTypes.WATER, 0.0F);
+    }
+
+    public void stop() {
+        this.dragon.getNavigation().stop();
+        this.dragon.setPathfindingMalus(BlockPathTypes.WATER, this.oldWaterCost);
+    }
+
+    public void tick() {
+        LivingEntity owner = this.dragon.getOwner();
+        this.dragon.getLookControl().setLookAt(owner, 10.0F, (float)this.dragon.getMaxHeadXRot());
+        if (--this.timeToRecalcPath <= 0) {
+            this.timeToRecalcPath = this.adjustedTickDelay(10);
+            if (!this.dragon.isLeashed() && !this.dragon.isPassenger()) {
+                if (this.dragon.distanceToSqr(owner) >= (this.teleportDistance * this.teleportDistance)) {
+                    this.teleportToOwner();
+                } else if (
+                        !this.dragon.isFlying()
+                                && this.dragon.canFly()
+                                && (owner.blockPosition().getY() - this.dragon.blockPosition().getY()) >= this.startDistance) {
+                    this.dragon.liftOff();
+                } else {
+                    this.dragon.getNavigation().moveTo(owner, this.speedModifier);
+                }
+
+            }
+        }
+    }
+
+    private void teleportToOwner() {
+        BlockPos ownerPos = this.dragon.getOwner().blockPosition();
+
+        for(int i = 0; i < 10; ++i) {
+            BlockPos target = this.randomBlockPosNearPos(
+                    ownerPos,
+                    MIN_HORIZONTAL_DISTANCE_FROM_PLAYER_WHEN_TELEPORTING,
+                    MAX_HORIZONTAL_DISTANCE_FROM_PLAYER_WHEN_TELEPORTING,
+                    MIN_VERTICAL_DISTANCE_FROM_PLAYER_WHEN_TELEPORTING,
+                    MAX_VERTICAL_DISTANCE_FROM_PLAYER_WHEN_TELEPORTING
+            );
+            boolean flag = this.maybeTeleportTo(target);
+            if (flag) {
+                return;
+            }
+        }
+
+    }
+
+    private boolean maybeTeleportTo(BlockPos pos) {
+        LivingEntity owner = this.dragon.getOwner();
+        if (owner.blockPosition().closerThan(pos, 2.0D)) {
+            return false;
+        } else if (!this.canTeleportTo(pos)) {
+            return false;
+        } else {
+            this.dragon.moveTo(pos.getX() + 0.5D, pos.getY(), pos.getZ(), this.dragon.getYRot(), this.dragon.getXRot());
+            this.dragon.getNavigation().stop();
+            return true;
+        }
+    }
+
+    private boolean canTeleportTo(BlockPos pos) {
+        if (!this.dragon.canFly()) {
+            BlockPathTypes blockpathtypes = WalkNodeEvaluator.getBlockPathTypeStatic(this.level, pos.mutable());
+            if (blockpathtypes != BlockPathTypes.WALKABLE) {
+                return false;
+            }
+
+            BlockState blockstate = this.level.getBlockState(pos.below());
+            if (blockstate.getBlock() instanceof LeavesBlock) {
+                return false;
+            }
+        }
+
+        BlockPos blockpos = pos.subtract(this.dragon.blockPosition());
+        return this.level.noCollision(this.dragon, this.dragon.getBoundingBox().move(blockpos));
+    }
+
+    private int randomIntInclusive(int min, int max) {
+        return this.dragon.getRandom().nextInt(max - min + 1) + min;
+    }
+
+    private int randomIntInclusive(int farLow, int nearLow, int nearHigh, int farHigh) {
+        if (nearLow == nearHigh)
+            return this.randomIntInclusive(farLow, farHigh);
+
+        return this.dragon.getRandom().nextBoolean() ?
+                this.randomIntInclusive(farLow, nearLow) :
+                this.randomIntInclusive(nearHigh, farHigh);
+    }
+
+    private BlockPos randomBlockPosNearPos(BlockPos origin, int minDist, int maxDist, int minYDist, int maxYDist) {
+        int x = this.randomIntInclusive(-maxDist, -minDist, minDist, maxDist);
+        int y = this.randomIntInclusive(-maxYDist, -minYDist, minYDist, maxYDist);
+        int z = this.randomIntInclusive(-maxDist, -minDist, minDist, maxDist);
+        return origin.offset(x, y, z);
+    }
+}


### PR DESCRIPTION
This PR fixes the following on the dragons in version 1.18.2 and adds a couple of nice-to-have changes.

I found out the `FollowOwnerGoal` was the source of the problem because it saved off the `PathNavigation` object and used that instead of the `TameableAnimal`'s `getNavigation` getter like most goals. I was originally going to create a wrapper extending `PathNavigation` that could switch and delegate the calls to the right navigation. That turned out to be a terrible solution because it was really hacky and brittle.

I opted to just copy and fix the `FollowOwnerGoal` instead. Much cleaner and easier. While I was in there, I made some changes to make the following feel a bit nicer.

### Summary

1. `DragonFollowOwnerGoal` takes a `TameableDragon` instead of a `TameableAnimal` so the goal can actually do things with the dragon's info.
2. Removed the hardcoded teleport range for a value that can be passed in.
3. Bumped the teleport distance from 12 to 32 so you can actually watch your dragons fly.
4. Made dragons teleport a couple of blocks away so they're not fighting for position with the player.
5. Allowed teleporting into the air for dragons that can fly.
6. Added a liftoff for dragons when their owner is high enough above.
    1. Bonus: this stops them from getting stuck on the ground if their owner flies off.
    2. Dragons that can't fly won't take off.
7. Removed the `FOLLOW_RANGE` attribute since it doesn't seem to do anything and I don't see it used on any other tameable animals.
    1. I tested with 0 and 5 range both on ground and flying and it was totally ignored.
8. Moved the navigations to the `TameableDragon` constructor so they aren't being instantiated every time they switch.

I will port over to 1.19.2 (should be really easy), but the code in that branch won't compile as-is for me and I don't want to mix this fix with that. (`BreedRegistry` and `DragonBreedProvider` are passing `HolderSet`s instead of `TagKey`s)

fixes #96 