### PR TITLE
Fix camera clipping [1.19]

### DIFF
--- a/src/main/java/com/github/kay9/dragonmounts/DragonMountsLegacy.java
+++ b/src/main/java/com/github/kay9/dragonmounts/DragonMountsLegacy.java
@@ -109,10 +109,10 @@ public class DragonMountsLegacy
                 case THIRD_PERSON_FRONT -> distance = 6;
                 case THIRD_PERSON_BACK -> {
                     distance = 6;
-                    vertical = 3;
+                    vertical = 4;
                 }
             }
-            camera.move(-distance, vertical, 0);
+            camera.move(-camera.getMaxZoom(distance), vertical, 0);
         }
     }
 


### PR DESCRIPTION
This PR fixes the camera clipping through terrain in 3rd person view while riding a dragon. The fix was to just pass the desired distance into the camera's `getMaxZoom` function. Basically just copy the usage in the Camera class itself.

Also increased the vertical a tiny bit so it doesn't clip into the dragon as much.

Fixes #93