### PR TITLE
Start dragon ai conversion

### DIFF
--- a/src/main/java/com/github/kay9/dragonmounts/dragon/ai/DragonAi.java
+++ b/src/main/java/com/github/kay9/dragonmounts/dragon/ai/DragonAi.java
@@ -1,0 +1,65 @@
+package com.github.kay9.dragonmounts.dragon.ai;
+
+import com.github.kay9.dragonmounts.DMLRegistry;
+import com.github.kay9.dragonmounts.dragon.TameableDragon;
+
+import com.mojang.datafixers.util.Pair;
+
+import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.entity.ai.behavior.*;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.schedule.Activity;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
+
+public class DragonAi
+{
+    public static Brain<?> makeBrain(Brain<TameableDragon> brain)
+    {
+        initCoreActivity(brain);
+        initIdleActivity(brain);
+        initFightActivity(brain);
+        brain.setCoreActivities(ImmutableSet.of(Activity.CORE));
+        brain.setDefaultActivity(Activity.IDLE);
+        brain.useDefaultActivity();
+        return brain;
+    }
+
+    private static void initCoreActivity(Brain<TameableDragon> brain) {
+        brain.addActivity(Activity.CORE, 0, ImmutableList.of(
+                new Swim(0.8f),
+                new LookAtTargetSink(45, 90),
+                new MoveToTargetSink()));
+    }
+
+    private static void initIdleActivity(Brain<TameableDragon> brain) {
+        brain.addActivity(Activity.IDLE, 10, ImmutableList.of(
+                new RunIf<>(TameableDragon::canBreed, new AnimalMakeLove(DMLRegistry.DRAGON.get(), 1.0F)),
+                new RunOne<>(ImmutableList.of(
+                        Pair.of(new RandomStroll(1.0f), 2),
+                        Pair.of(new SetWalkTargetFromLookTarget(1.0f, 3), 2),
+                        Pair.of(new DoNothing(30, 60), 1)))));
+    }
+
+    private static void initFightActivity(Brain<TameableDragon> brain) {
+        brain.addActivityAndRemoveMemoryWhenStopped(Activity.FIGHT, 10, ImmutableList.of(
+                new RunIf<>(TameableDragon::canBreed, new AnimalMakeLove(DMLRegistry.DRAGON.get(), 1.0F)),
+                new SetWalkTargetFromAttackTargetIfTargetOutOfReach(1.0F),
+                new RunIf<>(TameableDragon::isAdult, new MeleeAttack(40)),
+                new RunIf<>(TameableDragon::isBaby, new MeleeAttack(15)),
+                new StopAttackingIfTargetInvalid<>(),
+                new EraseMemoryIf<>(DragonAi::isBreeding, MemoryModuleType.ATTACK_TARGET)
+        ), MemoryModuleType.ATTACK_TARGET);
+    }
+
+    public static void updateActivity(TameableDragon dragon) {
+        dragon.getBrain().setActiveActivityToFirstValid(ImmutableList.of(
+                Activity.FIGHT,
+                Activity.IDLE));
+    }
+
+    private static boolean isBreeding(TameableDragon dragon) {
+        return dragon.getBrain().hasMemoryValue(MemoryModuleType.BREED_TARGET);
+    }
+}


### PR DESCRIPTION
In theory, this PR will completely convert the dragon ai to using the Brain API. In practice, we'll see if I get that far.

Opening this as a draft PR because I suspect it will be pretty large and take a fair bit of time plus wanted to keep it open for comments in-flight. Some of this might be better to create as separate PRs, but whatever, shoot for the moon.

## Todo list

### Phase 1 - Basics

Implement current ai logic limited to vanilla activities and behaviors.

- [ ] Remove existing goal ai
- [ ] Create core behaviors
  - [ ] Don't drown
  - [ ] Look at look target
  - [ ] Walk to walk target
- [ ] Create idle behaviors
  - [ ] Breeding
  - [ ] Random strolls
  - [ ] Random looking
  - [ ] Doing nothing
  - [ ] Non-tame random targeting
- [ ] Create fight behaviors

### Phase 2 - Custom

Implement remaining ai logic with custom activities, behaviors, and memories. No vanilla mobs using the Brain API are tameable, flying, or rideable+controllable, so any activities, behaviors, or memories for those will be implemented here.

- [ ] Extend core behaviors
  - [ ] Support flying movement
  - [ ] Aggro on owner attack target
  - [ ] Aggro on owner attacker
- [ ] Extend idle behaviors
  - [ ] Random flying stroll
  - [ ] Follow owner
  - [ ] Water avoiding strolls
- [ ] Create sit behaviors. 
  - [ ] Transition into/out of sit activity
  - [ ] Prevent some aggro while sitting. owner attack/attacked.
  - [ ] Probably still aggro when attacked? Transitions out of sitting? Separate activity for fighting while sitting? idk, something goes here.

### Phase 3 - Big Brain

Send these dragons to college. Do new things that are just easier with the Brain API so dragons are smarter.

- [ ] Maybe baby following adult. Can use a custom memory to switch between follow owner and follow parent.
- [ ] Make tamed dragons flee below a health threshold so they're less likely to die.
- [ ] Fight with breath weapons. Maybe prefer breath weapons at range, but have a cooldown to force melee in between.
  - [ ] Make sure any breath weapons wouldn't hit owner. Want to get ahead of dragons killing their owners.
- [ ] Breed while flying, but better.
- [ ] Don't allow aggro when being ridden.
- [ ] Allow owner control when aggressive. Probably just clear the attack target.
- [ ] Set a time or range limit on aggressive behavior.
- [ ] Better flight patterns maybe?
- [ ] Actual swimming behavior for some dragons?